### PR TITLE
Fix changelog creation

### DIFF
--- a/dist/simple-changeset.cjs.dev.js
+++ b/dist/simple-changeset.cjs.dev.js
@@ -267,7 +267,7 @@ async function getPackagesToRelease(packages) {
   }
   return [packages[0]];
 }
-async function getReleaseType() {
+async function getReleaseType$1() {
   return askList(`What kind of release should it be ?`, ["patch", "minor", "major"]);
 }
 async function getReleaseSummary() {
@@ -293,7 +293,7 @@ async function getReleaseSummary() {
 async function createChangeset(packages) {
   const releases = [];
   const packagesToRelease = await getPackagesToRelease(packages);
-  const releaseType = await getReleaseType();
+  const releaseType = await getReleaseType$1();
   for (const packageToRelease of packagesToRelease) {
     releases.push({
       name: packageToRelease,
@@ -437,12 +437,10 @@ function incrementVersion(oldVersion, type) {
 }
 
 function assembleReleasePlan(changesets, oldVersion) {
-  var _releasesArray$;
   const releases = flattenReleases(changesets, oldVersion);
-  const releasesArray = [...releases.values()];
-  const releasesType = (_releasesArray$ = releasesArray[0]) === null || _releasesArray$ === void 0 ? void 0 : _releasesArray$.type;
+  const releasesType = getReleaseType(releases);
   const newVersion = incrementVersion(oldVersion, releasesType);
-  const releasesWithNewVersion = releasesArray.map(incompleteRelease => {
+  const releasesWithNewVersion = releases.map(incompleteRelease => {
     return {
       ...incompleteRelease,
       newVersion
@@ -453,6 +451,17 @@ function assembleReleasePlan(changesets, oldVersion) {
     changesets,
     releases: releasesWithNewVersion
   };
+}
+function getReleaseType(releases) {
+  const hasMajorChange = releases.find(release => release.type === "major");
+  if (hasMajorChange) {
+    return "major";
+  }
+  const hasMinorChange = releases.find(release => release.type === "minor");
+  if (hasMinorChange) {
+    return "minor";
+  }
+  return "patch";
 }
 function flattenReleases(changesets, oldVersion) {
   let releases = new Map();
@@ -481,7 +490,7 @@ function flattenReleases(changesets, oldVersion) {
       releases.set(name, release);
     });
   });
-  return releases;
+  return [...releases.values()];
 }
 
 const isChangesetWithCommit = changeset => {
@@ -650,14 +659,14 @@ async function getChangelogSections(changesetsWithCommits, repo) {
           package: release.name,
           subsections: [subsectionContent]
         });
-        break;
-      }
-      const subsection = section.subsections.find(s => s.type === release.type);
-      if (subsection) {
-        subsection.changelogEntry += `
-${releaseLine}`;
       } else {
-        section.subsections.push(subsectionContent);
+        const subsection = section.subsections.find(s => s.type === release.type);
+        if (subsection) {
+          subsection.changelogEntry += `
+  ${releaseLine}`;
+        } else {
+          section.subsections.push(subsectionContent);
+        }
       }
     }
   }

--- a/dist/simple-changeset.cjs.prod.js
+++ b/dist/simple-changeset.cjs.prod.js
@@ -267,7 +267,7 @@ async function getPackagesToRelease(packages) {
   }
   return [packages[0]];
 }
-async function getReleaseType() {
+async function getReleaseType$1() {
   return askList(`What kind of release should it be ?`, ["patch", "minor", "major"]);
 }
 async function getReleaseSummary() {
@@ -293,7 +293,7 @@ async function getReleaseSummary() {
 async function createChangeset(packages) {
   const releases = [];
   const packagesToRelease = await getPackagesToRelease(packages);
-  const releaseType = await getReleaseType();
+  const releaseType = await getReleaseType$1();
   for (const packageToRelease of packagesToRelease) {
     releases.push({
       name: packageToRelease,
@@ -437,12 +437,10 @@ function incrementVersion(oldVersion, type) {
 }
 
 function assembleReleasePlan(changesets, oldVersion) {
-  var _releasesArray$;
   const releases = flattenReleases(changesets, oldVersion);
-  const releasesArray = [...releases.values()];
-  const releasesType = (_releasesArray$ = releasesArray[0]) === null || _releasesArray$ === void 0 ? void 0 : _releasesArray$.type;
+  const releasesType = getReleaseType(releases);
   const newVersion = incrementVersion(oldVersion, releasesType);
-  const releasesWithNewVersion = releasesArray.map(incompleteRelease => {
+  const releasesWithNewVersion = releases.map(incompleteRelease => {
     return {
       ...incompleteRelease,
       newVersion
@@ -453,6 +451,17 @@ function assembleReleasePlan(changesets, oldVersion) {
     changesets,
     releases: releasesWithNewVersion
   };
+}
+function getReleaseType(releases) {
+  const hasMajorChange = releases.find(release => release.type === "major");
+  if (hasMajorChange) {
+    return "major";
+  }
+  const hasMinorChange = releases.find(release => release.type === "minor");
+  if (hasMinorChange) {
+    return "minor";
+  }
+  return "patch";
 }
 function flattenReleases(changesets, oldVersion) {
   let releases = new Map();
@@ -481,7 +490,7 @@ function flattenReleases(changesets, oldVersion) {
       releases.set(name, release);
     });
   });
-  return releases;
+  return [...releases.values()];
 }
 
 const isChangesetWithCommit = changeset => {
@@ -650,14 +659,14 @@ async function getChangelogSections(changesetsWithCommits, repo) {
           package: release.name,
           subsections: [subsectionContent]
         });
-        break;
-      }
-      const subsection = section.subsections.find(s => s.type === release.type);
-      if (subsection) {
-        subsection.changelogEntry += `
-${releaseLine}`;
       } else {
-        section.subsections.push(subsectionContent);
+        const subsection = section.subsections.find(s => s.type === release.type);
+        if (subsection) {
+          subsection.changelogEntry += `
+  ${releaseLine}`;
+        } else {
+          section.subsections.push(subsectionContent);
+        }
       }
     }
   }

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,0 +1,14 @@
+
+## [2.1.0]  2023-02-22
+
+Introducing a changelog on this project since that takes the biscuit not to have a changelog on a changelog automation tool.
+Nevertheless, since the tool has a hard-coded packages list, we won't be able to use it right away on itself.
+
+For now, the tool has:
+- an `init` command that creates a `.changeset` folder with a default config (needs to be updated by the user) and a Readme
+- an `add` command that guides the user to add a "changeset" file:
+  - the user can choose one or several packages affected by his change. The packages list is hard-coded.
+  - the user can choose a type of change following semantic versioning convention
+  - the user can describe the change
+  - a changeset file containing all that information is created and committed
+- a `version` command that updates the `CHANGELOG.md` file and the `.changeset/version` file with the new version number, the date, and the change details. This command deletes all the changeset files that were taken into account. 

--- a/src/commands/version/getChangelogEntry.ts
+++ b/src/commands/version/getChangelogEntry.ts
@@ -28,17 +28,16 @@ export async function getChangelogSections(
           package: release.name,
           subsections: [subsectionContent],
         });
-        break;
-      }
-
-      const subsection = section.subsections.find(
-        (s) => s.type === release.type
-      );
-      if (subsection) {
-        subsection.changelogEntry += `
-${releaseLine}`;
       } else {
-        section.subsections.push(subsectionContent);
+        const subsection = section.subsections.find(
+          (s) => s.type === release.type
+        );
+        if (subsection) {
+          subsection.changelogEntry += `
+  ${releaseLine}`;
+        } else {
+          section.subsections.push(subsectionContent);
+        }
       }
     }
   }


### PR DESCRIPTION
When testing the tool, 2 bugs were found:
- a changeset with several packages changed would only result into one entry in the changelog, for the first updated package. Now, all the changed packages have their entry in the changelog file.
- the new version number was badly computed. It would always return the version type of the first computed changeset, instead of returning the highest change type that was made over all the changeset files (eg depending on the changesets order, we would only apply a patch increment instead of a minor one). This is solved.

Also, I added a changelog file for the project.